### PR TITLE
Update lucene-search plugin dependency to support Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ work
 .settings
 .classpath
 .project
+/bin/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,8 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useContainerAgent: true)
+buildPlugin(
+    useContainerAgent: true,
+    configurations: [
+        [platform: 'linux', jdk: 11]
+    ])

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<changelist>999999-SNAPSHOT</changelist>
 
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-		<jenkins.version>2.277.4</jenkins.version>
+		<jenkins.version>2.361.4</jenkins.version>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
 
@@ -47,8 +47,8 @@
 			<dependency>
 				<!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.277.x</artifactId>
-				<version>984.vb5eaac999a7e</version>
+				<artifactId>bom-2.361.x</artifactId>
+				<version>2070.vf6802449b_215</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>apache-httpcomponents-client-4-api</artifactId>
-			<version>4.5.13-1.0</version>
+			<version>4.5.14-150.v7a_b_9d17134a_5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>lucene-search</artifactId>
-			<version>370.v62a5f618cd3a</version>
+			<version>389.v52a_ec2810b_ca</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This updates the lucene-search plugin to support Java 11. This also enables this plugin to use Java 11. It also updates the minimal Jenkins version to 2.361.x.
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
