### PR TITLE
Fix build number extraction from query

### DIFF
--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
@@ -125,7 +125,7 @@ public class DirectCheckRunCollector implements CheckRunCollector {
         if (job == null) {
           throw new IllegalStateException("Couldn't find project returned by index query: " + hit.getProjectName());
         }
-        Run run = job.getBuild(hit.getSearchName().substring(1));
+        Run run = job.getBuild(hit.getSearchName().split("#")[1]);
         if (run == null) {
           throw new IllegalStateException(String.format("Couldn't find build %s for job %s returned by index query: ", hit.getSearchName(), job.getFullName()));
         }

--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
@@ -18,6 +18,7 @@ import com.google.gerrit.extensions.restapi.Url;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
+
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.security.ACL;
@@ -32,10 +33,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
+
+import org.apache.log4j.Logger;
+import org.jenkinsci.plugins.lucene.search.FreeTextSearchItemImplementation;
 import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 
 @Singleton
 public class DirectCheckRunCollector implements CheckRunCollector {
+    private static final Logger LOG = Logger.getLogger(DirectCheckRunCollector.class);
 
   private final Jenkins jenkins;
   private final Provider<SearchBackendManager> managerProvider;
@@ -70,13 +75,7 @@ public class DirectCheckRunCollector implements CheckRunCollector {
   private Map<Job<?, ?>, List<CheckRun>> collectGerritTriggerRuns(PatchSetId ps) {
     SearchBackendManager manager = getSearchBackendManager();
     try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
-      Map<Job<?, ?>, List<Run>> hits =
-          manager.getHits(String.format("p:\"refs/changes/%s\"", ps.toRef()), false).stream()
-              .map(
-                  hit ->
-                      jenkins
-                          .getItemByFullName(hit.getProjectName(), Job.class)
-                          .getBuild(hit.getSearchName().substring(1)))
+      Map<Job<?, ?>, List<Run>> hits = queryRuns(String.format("p:\"refs/changes/%s\"", ps.toRef()), manager).stream()
               .sorted(Comparator.comparing(Run::getNumber))
               .collect(Collectors.groupingBy(Run::getParent));
 
@@ -99,12 +98,7 @@ public class DirectCheckRunCollector implements CheckRunCollector {
     SearchBackendManager manager = getSearchBackendManager();
     try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
       Map<Job<?, ?>, List<Run>> runs =
-          manager.getHits(String.format("j:\"%s\"", convertToUrlEncodedRef(ps)), false).stream()
-              .map(
-                  hit ->
-                      jenkins
-                          .getItemByFullName(hit.getProjectName(), Job.class)
-                          .getBuild(hit.getSearchName().substring(1)))
+          queryRuns(String.format("j:\"%s\"", convertToUrlEncodedRef(ps)), manager).stream()
               .collect(Collectors.groupingBy(Run::getParent));
 
       Map<Job<?, ?>, List<CheckRun>> checkRuns = new HashMap<>();
@@ -120,6 +114,26 @@ public class DirectCheckRunCollector implements CheckRunCollector {
       }
       return checkRuns;
     }
+  }
+
+  @SuppressWarnings("rawtypes")
+  private List<Run> queryRuns(String query, SearchBackendManager manager) {
+      List<Run> foundRuns = new ArrayList<>();
+      for (FreeTextSearchItemImplementation hit : manager.getHits(query, false)) {
+        Job job = jenkins
+                .getItemByFullName(hit.getProjectName(), Job.class);
+        if (job == null) {
+          throw new IllegalStateException("Couldn't find project returned by index query: " + hit.getProjectName());
+        }
+        Run run = job.getBuild(hit.getSearchName().substring(1));
+        if (run == null) {
+          throw new IllegalStateException(String.format("Couldn't find build %s for job %s returned by index query: ", hit.getSearchName(), job.getFullName()));
+        }
+
+        LOG.debug(String.format("Found job %s build %s with parent %s", job.getFullName(), run.getNumber(), run.getParent()));
+        foundRuns.add(run);
+      }
+      return foundRuns;
   }
 
   private SearchBackendManager getSearchBackendManager() {


### PR DESCRIPTION
The code contained a wrong assumption that the searchName in the
query result would always be `#1` where `1` is the build number.
It could however be prefixed.

This fixes #5.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
