### PR TITLE
Fix/running time

### DIFF
--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/AbstractCheckRunFactory.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/AbstractCheckRunFactory.java
@@ -45,11 +45,17 @@ public abstract class AbstractCheckRunFactory {
   }
 
   protected static String computeFinishedTimeStamp(Run<?, ?> run) {
-    if (run.hasntStartedYet() || run.isBuilding()) {
+    if (run.hasntStartedYet()) {
       return null;
     }
+    long duration;
+    if (run.isBuilding()) {
+      duration = run.getEstimatedDuration();
+    } else {
+      duration = run.getDuration();
+    }
     return Instant.ofEpochMilli(run.getStartTimeInMillis())
-        .plusMillis(run.getDuration())
+        .plusMillis(duration)
         .toString();
   }
 


### PR DESCRIPTION
Fix report estimated completion time for in-progress runs
    
The `computeFinishedTimeStamp` method currently returns null if a
run is still building. This prevents Gerrit from displaying an
estimated completion time in the Checks UI.
    
Update the logic to use `run.getEstimatedDuration()` when the
build is active. This allows the plugin to export a predicted
timestamp based on historical data, improving the user experience
by showing when a check is expected to finish.
    
- If not started: returns null
- If building: returns StartTime + EstimatedDuration
- If finished: returns StartTime + ActualDuration

### Testing done

Deployed and tested in internal infrastructure. Now the ETA is shown in Check Jenkins UI plugin

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
