### PR TITLE
Feat/add upstream downstream connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>lucene-search</artifactId>
       <version>425.v2ccf4cc3a_d55</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
@@ -19,18 +19,28 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
+import hudson.model.Cause;
 import hudson.model.Job;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import io.jenkins.plugins.gerritchecksapi.rest.CheckRun;
+import io.jenkins.plugins.gerritchecksapi.rest.CheckResult;
+import io.jenkins.plugins.gerritchecksapi.rest.CheckResult.Category;
+import io.jenkins.plugins.gerritchecksapi.rest.AbstractCheckRunFactory;
 import io.jenkins.plugins.gerritchecksapi.rest.GerritMultiBranchCheckRunFactory;
 import io.jenkins.plugins.gerritchecksapi.rest.GerritTriggerCheckRunFactory;
+import io.jenkins.plugins.gerritchecksapi.rest.Link;
+import io.jenkins.plugins.gerritchecksapi.rest.Link.LinkIcon;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 
@@ -41,6 +51,8 @@ import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 @Singleton
 public class DirectCheckRunCollector implements CheckRunCollector {
     private static final Logger LOG = Logger.getLogger(DirectCheckRunCollector.class);
+    private static final int MAX_DOWNSTREAM_DEPTH = 10;
+    private static final int MAX_RECENT_BUILDS_PER_JOB = 100;
 
   private final Jenkins jenkins;
   private final Provider<SearchBackendManager> managerProvider;
@@ -68,6 +80,7 @@ public class DirectCheckRunCollector implements CheckRunCollector {
     if (jenkins.getPlugin("gerrit-code-review") != null) {
       checkRuns.putAll(collectGerritMultiBranchRuns(ps));
     }
+    collectDownstreamCheckRuns(ps, checkRuns);
     return checkRuns;
   }
 
@@ -146,5 +159,175 @@ public class DirectCheckRunCollector implements CheckRunCollector {
 
   private static String convertToUrlEncodedRef(PatchSetId ps) {
     return Url.encode(ps.toRef());
+  }
+
+  @SuppressWarnings("rawtypes")
+  private void collectDownstreamCheckRuns(
+      PatchSetId ps, Map<Job<?, ?>, List<CheckRun>> checkRuns) {
+    Set<String> directRunIds = new HashSet<>();
+    Map<String, CheckRun> directRunByExtId = new HashMap<>();
+    for (List<CheckRun> runs : checkRuns.values()) {
+      for (CheckRun cr : runs) {
+        directRunIds.add(cr.getExternalId());
+        directRunByExtId.put(cr.getExternalId(), cr);
+      }
+    }
+    if (directRunIds.isEmpty()) {
+      return;
+    }
+
+    Map<String, List<Run<?, ?>>> downstreamMap = buildDownstreamMap();
+    Set<String> traversed = new HashSet<>(directRunIds);
+    for (String rootKey : directRunIds) {
+      List<Run<?, ?>> children = downstreamMap.get(rootKey);
+      if (children != null) {
+        for (Run<?, ?> child : children) {
+          String childKey = child.getExternalizableId();
+          if (directRunByExtId.containsKey(childKey)) {
+            CheckRun directRun = directRunByExtId.remove(childKey);
+            directRun.setExternalId(
+                buildDownstreamExternalId(rootKey, childKey));
+          } else {
+            Job<?, ?> childJob = child.getParent();
+            checkRuns.computeIfAbsent(childJob, k -> new ArrayList<>()).add(
+                createDownstreamCheckRun(ps, rootKey, child, childJob));
+          }
+          if (traversed.add(childKey)) {
+            traverseDownstream(ps, childKey, child, checkRuns,
+                downstreamMap, traversed, directRunIds, directRunByExtId, 1);
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  private Map<String, List<Run<?, ?>>> buildDownstreamMap() {
+    Map<String, List<Run<?, ?>>> downstreamMap = new HashMap<>();
+    try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+      for (Job<?, ?> job : jenkins.getAllItems(Job.class)) {
+        int count = 0;
+        for (Run<?, ?> run : job.getBuilds()) {
+          if (count++ >= MAX_RECENT_BUILDS_PER_JOB) {
+            break;
+          }
+          if (run == null) {
+            continue;
+          }
+          for (Cause cause : run.getCauses()) {
+            if (cause instanceof Cause.UpstreamCause) {
+              Cause.UpstreamCause uc = (Cause.UpstreamCause) cause;
+              String upstreamKey =
+                  uc.getUpstreamProject() + "#" + uc.getUpstreamBuild();
+              downstreamMap
+                  .computeIfAbsent(upstreamKey, k -> new ArrayList<>())
+                  .add(run);
+            }
+          }
+        }
+      }
+    }
+    return downstreamMap;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private void traverseDownstream(
+      PatchSetId ps,
+      String upstreamKey,
+      Run<?, ?> upstreamRun,
+      Map<Job<?, ?>, List<CheckRun>> checkRuns,
+      Map<String, List<Run<?, ?>>> downstreamMap,
+      Set<String> traversed,
+      Set<String> directRunIds,
+      Map<String, CheckRun> directRunByExtId,
+      int depth) {
+
+    if (depth >= MAX_DOWNSTREAM_DEPTH) {
+      LOG.warn(String.format(
+          "Reached max downstream depth %d at run %s",
+          MAX_DOWNSTREAM_DEPTH, upstreamKey));
+      return;
+    }
+
+    List<Run<?, ?>> children = downstreamMap.get(upstreamKey);
+    if (children == null) {
+      return;
+    }
+
+    for (Run<?, ?> child : children) {
+      String childKey = child.getExternalizableId();
+      if (directRunByExtId.containsKey(childKey)) {
+        CheckRun directRun = directRunByExtId.remove(childKey);
+        directRun.setExternalId(
+            buildDownstreamExternalId(upstreamKey, childKey));
+      } else {
+        Job<?, ?> childJob = child.getParent();
+        checkRuns.computeIfAbsent(childJob, k -> new ArrayList<>()).add(
+            createDownstreamCheckRun(ps, upstreamKey, child, childJob));
+      }
+      if (traversed.add(childKey)) {
+        traverseDownstream(ps, childKey, child, checkRuns,
+            downstreamMap, traversed, directRunIds,
+            directRunByExtId, depth + 1);
+      }
+    }
+  }
+
+  private static String buildDownstreamExternalId(
+      String parentKey, String runKey) {
+    return String.format(
+        "{\"parent\":\"%s\",\"run\":\"%s\"}", parentKey, runKey);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private CheckRun createDownstreamCheckRun(
+      PatchSetId ps,
+      String upstreamKey,
+      Run<?, ?> run,
+      Job<?, ?> job) {
+
+    String runId = run.getExternalizableId();
+    String externalId = buildDownstreamExternalId(upstreamKey, runId);
+
+    String runUrl = String.format("%s%s", jenkins.getRootUrl(), run.getUrl());
+
+    CheckRun checkRun = new CheckRun();
+    checkRun.setChange(ps.changeId());
+    checkRun.setPatchSet(ps.patchSetNumber());
+    checkRun.setAttempt(1);
+    checkRun.setExternalId(externalId);
+    checkRun.setCheckName(job.getDisplayName());
+    checkRun.setCheckDescription(job.getDescription());
+    checkRun.setCheckLink(runUrl);
+    checkRun.setStatus(AbstractCheckRunFactory.computeStatus(run));
+    checkRun.setStatusDescription(run.getBuildStatusSummary().message);
+    checkRun.setStatusLink(runUrl);
+    checkRun.setLabelName(null);
+    checkRun.setActions(new ArrayList<>());
+    checkRun.setScheduledTimestamp(run.getTime().toInstant().toString());
+    checkRun.setStartedTimestamp(
+        Instant.ofEpochMilli(run.getStartTimeInMillis()).toString());
+    checkRun.setFinishedTimestamp(
+        AbstractCheckRunFactory.computeFinishedTimeStamp(run));
+
+    List<CheckResult> results = new ArrayList<>();
+    if (!run.hasntStartedYet() && !run.isBuilding()) {
+      CheckResult result = new CheckResult();
+      result.setExternalId(externalId);
+      Result jenkinsResult = run.getResult();
+      if (jenkinsResult != null) {
+        result.setCategory(Category.fromResult(jenkinsResult));
+      }
+      Link consoleLink = new Link();
+      consoleLink.setUrl(String.format("%sconsole", runUrl));
+      consoleLink.setTooltip("Build log.");
+      consoleLink.setIcon(LinkIcon.CODE);
+      consoleLink.setPrimary(true);
+      result.setLinks(List.of(consoleLink));
+      results.add(result);
+    }
+    checkRun.setResults(results);
+
+    return checkRun;
   }
 }

--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/AbstractCheckRunFactory.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/AbstractCheckRunFactory.java
@@ -34,7 +34,7 @@ public abstract class AbstractCheckRunFactory {
   protected abstract List<Action> computeActions(Run<?, ?> run);
 
   // TODO(Thomas): Add RUNNABLE status
-  protected static RunStatus computeStatus(Run<?, ?> run) {
+  public static RunStatus computeStatus(Run<?, ?> run) {
     if (run.hasntStartedYet()) {
       return RunStatus.SCHEDULED;
     }
@@ -44,7 +44,7 @@ public abstract class AbstractCheckRunFactory {
     return RunStatus.COMPLETED;
   }
 
-  protected static String computeFinishedTimeStamp(Run<?, ?> run) {
+  public static String computeFinishedTimeStamp(Run<?, ?> run) {
     if (run.hasntStartedYet()) {
       return null;
     }

--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/CheckResult.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/CheckResult.java
@@ -123,7 +123,7 @@ public class CheckResult {
     this.fixes = fixes;
   }
 
-  enum Category {
+  public enum Category {
     SUCCESS,
     INFO,
     WARNING,

--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/Link.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/rest/Link.java
@@ -61,7 +61,7 @@ public class Link {
     this.icon = icon;
   }
 
-  enum LinkIcon {
+  public enum LinkIcon {
     EXTERNAL,
     IMAGE,
     HISTORY,

--- a/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
+++ b/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
@@ -1,0 +1,322 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.jenkins.plugins.gerritchecksapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Provider;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import io.jenkins.plugins.gerritchecksapi.rest.CheckRun;
+import io.jenkins.plugins.gerritchecksapi.rest.GerritMultiBranchCheckRunFactory;
+import io.jenkins.plugins.gerritchecksapi.rest.GerritTriggerCheckRunFactory;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.lucene.search.FreeTextSearchItemImplementation;
+import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+class DirectCheckRunCollectorTest {
+
+  @Mock private Jenkins jenkins;
+  @Mock private Provider<SearchBackendManager> managerProvider;
+  @Mock private SearchBackendManager manager;
+  @Mock private GerritTriggerCheckRunFactory triggerFactory;
+  @Mock private GerritMultiBranchCheckRunFactory multiBranchFactory;
+
+  private DirectCheckRunCollector collector;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(managerProvider.get()).thenReturn(manager);
+    when(jenkins.getRootUrl()).thenReturn("http://jenkins/");
+    collector = new DirectCheckRunCollector(
+        jenkins, managerProvider, triggerFactory, multiBranchFactory);
+  }
+
+  // --- helpers ---
+
+  private Run mockRun(String fullJobName, int buildNumber, Job parentJob) {
+    Run run = mock(Run.class);
+    when(run.getExternalizableId()).thenReturn(fullJobName + "#" + buildNumber);
+    when(run.getNumber()).thenReturn(buildNumber);
+    when(run.getParent()).thenReturn(parentJob);
+    when(run.getUrl()).thenReturn("job/" + fullJobName + "/" + buildNumber + "/");
+    when(run.getTime()).thenReturn(new Date(1_000_000L));
+    when(run.getStartTimeInMillis()).thenReturn(1_000_500L);
+    when(run.getDuration()).thenReturn(500L);
+    when(run.getEstimatedDuration()).thenReturn(600L);
+    when(run.hasntStartedYet()).thenReturn(false);
+    when(run.isBuilding()).thenReturn(false);
+    when(run.getResult()).thenReturn(Result.SUCCESS);
+    when(run.getBuildStatusSummary()).thenReturn(new Run.Summary(false, "stable"));
+    return run;
+  }
+
+  private Job mockJob(String fullName, String displayName) {
+    Job job = mock(Job.class);
+    when(job.getFullName()).thenReturn(fullName);
+    when(job.getDisplayName()).thenReturn(displayName);
+    when(job.getDescription()).thenReturn("description of " + displayName);
+    return job;
+  }
+
+  private FreeTextSearchItemImplementation mockHit(
+      String projectName, String searchName) {
+    return new FreeTextSearchItemImplementation(
+        searchName, projectName, new String[0], "", false);
+  }
+
+  private CheckRun createPlainCheckRun(int change, int patchset, String externalId) {
+    CheckRun cr = new CheckRun();
+    cr.setChange(change);
+    cr.setPatchSet(patchset);
+    cr.setExternalId(externalId);
+    cr.setAttempt(1);
+    return cr;
+  }
+
+  // --- verification of existing behavior ---
+
+  @Test
+  void collectFor_noPluginsInstalled_returnsEmpty() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(null);
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void collectFor_oneDirectRun_noDownstream_returnsOneRun() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job job = mockJob("trigger-job", "trigger-job");
+    Run run = mockRun("trigger-job", 5, job);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("trigger-job", "trigger-job#5")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(job);
+    when(job.getBuild("5")).thenReturn(run);
+
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    assertEquals(1, result.size());
+    assertEquals("trigger-job#5", result.get(job).get(0).getExternalId());
+  }
+
+  @Test
+  void collectFor_noLuceneHits_returnsEmpty() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void collectFor_bothPluginsInstalled_mergesResults() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(mock(hudson.Plugin.class));
+
+    Job jobA = mockJob("trigger-job", "trigger-job");
+    Run runA = mockRun("trigger-job", 1, jobA);
+
+    Job jobB = mockJob("multibranch-job", "multibranch-job");
+    Run runB = mockRun("multibranch-job/main", 1, jobB);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(
+            Collections.singletonList(mockHit("trigger-job", "trigger-job#1")),
+            Collections.singletonList(mockHit("multibranch-job", "multibranch-job/main#1")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(jobA);
+    when(jenkins.getItemByFullName("multibranch-job", Job.class)).thenReturn(jobB);
+    when(jobA.getBuild("1")).thenReturn(runA);
+    when(jobB.getBuild("1")).thenReturn(runB);
+
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#1"));
+    when(multiBranchFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "multibranch-job/main#1"));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+    assertEquals(2, result.size());
+  }
+
+  @Test
+  void collectFor_gerritTriggerMultipleAttempts_sequentialNumbers() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job job = mockJob("trigger-job", "trigger-job");
+    Run run5 = mockRun("trigger-job", 5, job);
+    Run run12 = mockRun("trigger-job", 12, job);
+
+    when(manager.getHits(anyString(), anyBoolean())).thenReturn(List.of(
+        mockHit("trigger-job", "trigger-job#12"),
+        mockHit("trigger-job", "trigger-job#5")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(job);
+    when(job.getBuild("5")).thenReturn(run5);
+    when(job.getBuild("12")).thenReturn(run12);
+
+    when(triggerFactory.create(any(), eq(job), eq(run5), eq(1)))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
+    when(triggerFactory.create(any(), eq(job), eq(run12), eq(2)))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#12"));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    assertEquals(1, result.size());
+    assertEquals(2, result.get(job).size());
+  }
+
+  @Test
+  void collectFor_gerritTriggerMultipleJobs_perJobGrouping() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job jobA = mockJob("job-a", "job-a");
+    Run runA = mockRun("job-a", 1, jobA);
+    Job jobB = mockJob("job-b", "job-b");
+    Run runB = mockRun("job-b", 3, jobB);
+
+    when(manager.getHits(anyString(), anyBoolean())).thenReturn(List.of(
+        mockHit("job-a", "job-a#1"),
+        mockHit("job-b", "job-b#3")));
+    when(jenkins.getItemByFullName("job-a", Job.class)).thenReturn(jobA);
+    when(jenkins.getItemByFullName("job-b", Job.class)).thenReturn(jobB);
+    when(jobA.getBuild("1")).thenReturn(runA);
+    when(jobB.getBuild("3")).thenReturn(runB);
+
+    when(triggerFactory.create(any(), eq(jobA), eq(runA), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "job-a#1"));
+    when(triggerFactory.create(any(), eq(jobB), eq(runB), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "job-b#3"));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    assertEquals(2, result.size());
+    assertTrue(result.containsKey(jobA));
+    assertTrue(result.containsKey(jobB));
+    assertEquals(1, result.get(jobA).size());
+    assertEquals(1, result.get(jobB).size());
+  }
+
+  @Test
+  void collectFor_gerritMultiBranch_passesRunNumberAsAttempt() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(null);
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(mock(hudson.Plugin.class));
+
+    Job job = mockJob("mbp/branch", "mbp");
+    Run run = mockRun("mbp/branch", 7, job);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("mbp/branch", "mbp/branch#7")));
+    when(jenkins.getItemByFullName("mbp/branch", Job.class)).thenReturn(job);
+    when(job.getBuild("7")).thenReturn(run);
+
+    when(multiBranchFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "mbp/branch#7"));
+
+    collector.collectFor(PatchSetId.create(42, 3));
+
+    verify(multiBranchFactory).create(any(), any(), eq(run), eq(7));
+  }
+
+  @Test
+  void collectFor_searchBackendManagerNull_throwsMissingDependencyException() {
+    when(managerProvider.get()).thenReturn(null);
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+
+    assertThrows(MissingDependencyException.class,
+        () -> collector.collectFor(PatchSetId.create(1, 1)));
+  }
+
+  @Test
+  void patchSetId_toRef_correctFormat() {
+    assertEquals("23/123/5", PatchSetId.create(123, 5).toRef());
+    assertEquals("07/7/1", PatchSetId.create(7, 1).toRef());
+    assertEquals("45/12345/3", PatchSetId.create(12345, 3).toRef());
+  }
+
+  @Test
+  void patchSetId_equalsAndHashCode() {
+    PatchSetId a1 = PatchSetId.create(1, 1);
+    PatchSetId a2 = PatchSetId.create(1, 1);
+    PatchSetId b = PatchSetId.create(1, 2);
+    PatchSetId c = PatchSetId.create(2, 1);
+
+    assertEquals(a1, a2);
+    assertEquals(a1.hashCode(), a2.hashCode());
+    assertEquals(a1, a1);
+    org.junit.jupiter.api.Assertions.assertNotEquals(a1, null);
+    org.junit.jupiter.api.Assertions.assertNotEquals(a1, "string");
+    org.junit.jupiter.api.Assertions.assertNotEquals(a1, b);
+    org.junit.jupiter.api.Assertions.assertNotEquals(a1, c);
+  }
+
+  @Test
+  void queryRuns_jobNotFoundByLucene_throwsIllegalStateException() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("ghost-job", "ghost-job#1")));
+    when(jenkins.getItemByFullName("ghost-job", Job.class)).thenReturn(null);
+
+    assertThrows(IllegalStateException.class,
+        () -> collector.collectFor(PatchSetId.create(1, 1)));
+  }
+
+  @Test
+  void queryRuns_buildNotFoundByLucene_throwsIllegalStateException() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job job = mockJob("real-job", "real-job");
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("real-job", "real-job#99")));
+    when(jenkins.getItemByFullName("real-job", Job.class)).thenReturn(job);
+    when(job.getBuild("99")).thenReturn(null);
+
+    assertThrows(IllegalStateException.class,
+        () -> collector.collectFor(PatchSetId.create(1, 1)));
+  }
+}

--- a/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
+++ b/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
@@ -15,6 +15,7 @@
 package io.jenkins.plugins.gerritchecksapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,14 +23,17 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.inject.Provider;
+import hudson.model.Cause;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
+import hudson.util.RunList;
 import io.jenkins.plugins.gerritchecksapi.rest.CheckRun;
 import io.jenkins.plugins.gerritchecksapi.rest.GerritMultiBranchCheckRunFactory;
 import io.jenkins.plugins.gerritchecksapi.rest.GerritTriggerCheckRunFactory;
@@ -92,6 +96,23 @@ class DirectCheckRunCollectorTest {
     return job;
   }
 
+  /** Pre-create cause — UpstreamCause ctor internally calls run.getNumber()
+   *  which must not happen inside a when().thenReturn() chain. */
+  private Cause.UpstreamCause upstreamCause(Run run) {
+    return new Cause.UpstreamCause(run);
+  }
+
+  /**
+   * Sets job.getBuilds() to return a RunList containing the given runs.
+   * Must use doReturn+RunList mock because RunList.iterator() is final
+   * and RunList add() is unsupported on the real class.
+   */
+  private void setJobBuilds(Job job, Run... runs) {
+    RunList list = mock(RunList.class);
+    doReturn(List.of(runs).iterator()).when(list).iterator();
+    doReturn(list).when(job).getBuilds();
+  }
+
   private FreeTextSearchItemImplementation mockHit(
       String projectName, String searchName) {
     return new FreeTextSearchItemImplementation(
@@ -107,7 +128,7 @@ class DirectCheckRunCollectorTest {
     return cr;
   }
 
-  // --- verification of existing behavior ---
+  // --- tests ---
 
   @Test
   void collectFor_noPluginsInstalled_returnsEmpty() {
@@ -141,6 +162,128 @@ class DirectCheckRunCollectorTest {
   }
 
   @Test
+  void collectFor_oneDownstream_notInLucene_createsCheckRun() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job upstreamJob = mockJob("trigger-job", "trigger-job");
+    Run upstreamRun = mockRun("trigger-job", 5, upstreamJob);
+
+    Job downstreamJob = mockJob("downstream-job", "downstream-job");
+    Run downstreamRun = mockRun("downstream-job", 3, downstreamJob);
+
+    // Pre-create all objects that call mock methods BEFORE any when() chain
+    Cause.UpstreamCause downstreamCause = upstreamCause(upstreamRun);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("trigger-job", "trigger-job#5")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(upstreamJob);
+    when(upstreamJob.getBuild("5")).thenReturn(upstreamRun);
+
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
+
+    when(downstreamRun.getCauses()).thenReturn(Collections.singletonList(downstreamCause));
+    setJobBuilds(downstreamJob, downstreamRun);
+    when(jenkins.getAllItems(Job.class)).thenReturn(Collections.singletonList(downstreamJob));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    assertEquals(2, result.size());
+    List<CheckRun> downstreamChecks = result.get(downstreamJob);
+    assertNotNull(downstreamChecks);
+    assertEquals(1, downstreamChecks.size());
+    assertEquals("{\"parent\":\"trigger-job#5\",\"run\":\"downstream-job#3\"}",
+        downstreamChecks.get(0).getExternalId());
+  }
+
+  @Test
+  void collectFor_downstreamAlsoInLucene_updatesExternalId_noDuplicate() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job upstreamJob = mockJob("trigger-job", "trigger-job");
+    Run upstreamRun = mockRun("trigger-job", 5, upstreamJob);
+
+    Job downstreamJob = mockJob("downstream-job", "downstream-job");
+    Run downstreamRun = mockRun("downstream-job", 3, downstreamJob);
+
+    // Pre-create BEFORE any when() chain
+    Cause.UpstreamCause downstreamCause = upstreamCause(upstreamRun);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(List.of(
+            mockHit("trigger-job", "trigger-job#5"),
+            mockHit("downstream-job", "downstream-job#3")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(upstreamJob);
+    when(jenkins.getItemByFullName("downstream-job", Job.class)).thenReturn(downstreamJob);
+    when(upstreamJob.getBuild("5")).thenReturn(upstreamRun);
+    when(downstreamJob.getBuild("3")).thenReturn(downstreamRun);
+
+    CheckRun upstreamCR = createPlainCheckRun(1, 1, "trigger-job#5");
+    CheckRun downstreamCR = createPlainCheckRun(1, 1, "downstream-job#3");
+    when(triggerFactory.create(any(), eq(upstreamJob), eq(upstreamRun), anyInt()))
+        .thenReturn(upstreamCR);
+    when(triggerFactory.create(any(), eq(downstreamJob), eq(downstreamRun), anyInt()))
+        .thenReturn(downstreamCR);
+
+    when(downstreamRun.getCauses()).thenReturn(Collections.singletonList(downstreamCause));
+    setJobBuilds(downstreamJob, downstreamRun);
+    when(jenkins.getAllItems(Job.class)).thenReturn(Collections.singletonList(downstreamJob));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    List<CheckRun> downstreamChecks = result.get(downstreamJob);
+    assertNotNull(downstreamChecks);
+    assertEquals(1, downstreamChecks.size(),
+        "Should have exactly one CheckRun — no duplicate");
+    assertEquals("{\"parent\":\"trigger-job#5\",\"run\":\"downstream-job#3\"}",
+        downstreamChecks.get(0).getExternalId());
+  }
+
+  @Test
+  void collectFor_deepChain_allDownstreamsDiscovered() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    // A -> B -> C
+    Job jobA = mockJob("job-a", "job-a");
+    Run runA = mockRun("job-a", 1, jobA);
+
+    Job jobB = mockJob("job-b", "job-b");
+    Run runB = mockRun("job-b", 2, jobB);
+
+    Job jobC = mockJob("job-c", "job-c");
+    Run runC = mockRun("job-c", 3, jobC);
+
+    // Pre-create ALL causes BEFORE any when() chain
+    Cause.UpstreamCause causeB = upstreamCause(runA);
+    Cause.UpstreamCause causeC = upstreamCause(runB);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("job-a", "job-a#1")));
+    when(jenkins.getItemByFullName("job-a", Job.class)).thenReturn(jobA);
+    when(jobA.getBuild("1")).thenReturn(runA);
+
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "job-a#1"));
+
+    when(runB.getCauses()).thenReturn(Collections.singletonList(causeB));
+    when(runC.getCauses()).thenReturn(Collections.singletonList(causeC));
+    setJobBuilds(jobB, runB);
+    setJobBuilds(jobC, runC);
+    when(jenkins.getAllItems(Job.class)).thenReturn(List.of(jobB, jobC));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    assertEquals(3, result.size(), "Should have runs for A, B, and C");
+    assertEquals("{\"parent\":\"job-a#1\",\"run\":\"job-b#2\"}",
+        result.get(jobB).get(0).getExternalId());
+    assertEquals("{\"parent\":\"job-b#2\",\"run\":\"job-c#3\"}",
+        result.get(jobC).get(0).getExternalId());
+  }
+
+  @Test
   void collectFor_noLuceneHits_returnsEmpty() {
     when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
     when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
@@ -149,6 +292,40 @@ class DirectCheckRunCollectorTest {
 
     Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
     assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void collectFor_downstreamRerunAction_notAdded() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job upstreamJob = mockJob("trigger-job", "trigger-job");
+    Run upstreamRun = mockRun("trigger-job", 5, upstreamJob);
+
+    Job downstreamJob = mockJob("downstream-job", "downstream-job");
+    Run downstreamRun = mockRun("downstream-job", 3, downstreamJob);
+
+    // Pre-create BEFORE any when() chain
+    Cause.UpstreamCause downstreamCause = upstreamCause(upstreamRun);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("trigger-job", "trigger-job#5")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(upstreamJob);
+    when(upstreamJob.getBuild("5")).thenReturn(upstreamRun);
+
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
+
+    when(downstreamRun.getCauses()).thenReturn(Collections.singletonList(downstreamCause));
+    setJobBuilds(downstreamJob, downstreamRun);
+    when(jenkins.getAllItems(Job.class)).thenReturn(Collections.singletonList(downstreamJob));
+
+    Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
+
+    List<CheckRun> downstreamChecks = result.get(downstreamJob);
+    assertNotNull(downstreamChecks);
+    assertTrue(downstreamChecks.get(0).getActions().isEmpty(),
+        "Downstream CheckRun should have no rerun action");
   }
 
   @Test
@@ -180,6 +357,8 @@ class DirectCheckRunCollectorTest {
     assertEquals(2, result.size());
   }
 
+  // --- regression: normal use cases that must not break ---
+
   @Test
   void collectFor_gerritTriggerMultipleAttempts_sequentialNumbers() {
     when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
@@ -189,6 +368,7 @@ class DirectCheckRunCollectorTest {
     Run run5 = mockRun("trigger-job", 5, job);
     Run run12 = mockRun("trigger-job", 12, job);
 
+    // Return hits in reverse order — collector must sort by build number
     when(manager.getHits(anyString(), anyBoolean())).thenReturn(List.of(
         mockHit("trigger-job", "trigger-job#12"),
         mockHit("trigger-job", "trigger-job#5")));
@@ -196,15 +376,18 @@ class DirectCheckRunCollectorTest {
     when(job.getBuild("5")).thenReturn(run5);
     when(job.getBuild("12")).thenReturn(run12);
 
-    when(triggerFactory.create(any(), eq(job), eq(run5), eq(1)))
-        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
-    when(triggerFactory.create(any(), eq(job), eq(run12), eq(2)))
-        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#12"));
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"),
+                    createPlainCheckRun(1, 1, "trigger-job#12"));
 
     Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
 
     assertEquals(1, result.size());
     assertEquals(2, result.get(job).size());
+
+    // Verify factory was called with attempt=1 for build#5, attempt=2 for build#12
+    verify(triggerFactory).create(any(), any(), eq(run5), eq(1));
+    verify(triggerFactory).create(any(), any(), eq(run12), eq(2));
   }
 
   @Test
@@ -225,10 +408,9 @@ class DirectCheckRunCollectorTest {
     when(jobA.getBuild("1")).thenReturn(runA);
     when(jobB.getBuild("3")).thenReturn(runB);
 
-    when(triggerFactory.create(any(), eq(jobA), eq(runA), anyInt()))
-        .thenReturn(createPlainCheckRun(1, 1, "job-a#1"));
-    when(triggerFactory.create(any(), eq(jobB), eq(runB), anyInt()))
-        .thenReturn(createPlainCheckRun(1, 1, "job-b#3"));
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "job-a#1"),
+                    createPlainCheckRun(1, 1, "job-b#3"));
 
     Map<Job<?, ?>, List<CheckRun>> result = collector.collectFor(PatchSetId.create(1, 1));
 
@@ -257,6 +439,7 @@ class DirectCheckRunCollectorTest {
 
     collector.collectFor(PatchSetId.create(42, 3));
 
+    // gerrit-code-review factory should receive run.getNumber() (=7) as attempt
     verify(multiBranchFactory).create(any(), any(), eq(run), eq(7));
   }
 
@@ -271,8 +454,11 @@ class DirectCheckRunCollectorTest {
 
   @Test
   void patchSetId_toRef_correctFormat() {
+    // Change 123, patchset 5 → refs/changes/23/123/5
     assertEquals("23/123/5", PatchSetId.create(123, 5).toRef());
+    // Single digit change: 7, patchset 1 → refs/changes/07/7/1
     assertEquals("07/7/1", PatchSetId.create(7, 1).toRef());
+    // Large change: 12345, patchset 3 → refs/changes/45/12345/3
     assertEquals("45/12345/3", PatchSetId.create(12345, 3).toRef());
   }
 
@@ -286,14 +472,19 @@ class DirectCheckRunCollectorTest {
     assertEquals(a1, a2);
     assertEquals(a1.hashCode(), a2.hashCode());
     assertEquals(a1, a1);
+    // Not equal to null or different type
     org.junit.jupiter.api.Assertions.assertNotEquals(a1, null);
     org.junit.jupiter.api.Assertions.assertNotEquals(a1, "string");
+    // Different patchset
     org.junit.jupiter.api.Assertions.assertNotEquals(a1, b);
+    // Different change
     org.junit.jupiter.api.Assertions.assertNotEquals(a1, c);
   }
 
   @Test
   void queryRuns_jobNotFoundByLucene_throwsIllegalStateException() {
+    // This test verifies the error path when the lucene index is stale:
+    // a hit references a project that no longer exists.
     when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
     when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
 
@@ -307,6 +498,7 @@ class DirectCheckRunCollectorTest {
 
   @Test
   void queryRuns_buildNotFoundByLucene_throwsIllegalStateException() {
+    // Lucene hit references a build that no longer exists (stale index).
     when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
     when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
 


### PR DESCRIPTION
# Add downstream build discovery via Cause.UpstreamCause traversal

## Problem

When a complex Jenkins pipeline triggers downstream builds (e.g., a gerrit-triggered job that kicks off integration tests, then deployment verification), those downstream builds are invisible in the Gerrit Checks UI. The plugin only found builds whose lucene-search index entries directly contain the Gerrit ref string.

## Solution

The plugin now discovers **all transitive downstream builds** by scanning Jenkins jobs for `Cause.UpstreamCause` entries pointing to gerrit-triggered runs. Each downstream build appears as a separate `CheckRun` whose `externalId` encodes the parent→child relationship as a JSON object:

```json
{"parent": "trigger-job#5", "run": "downstream-job#3"}
```

The Gerrit Checks UI frontend is responsible for resolving the graph from these edges and rendering the pipeline visualization.

### Key behaviors

- **Full recursive traversal** — follows the entire downstream chain (A→B→C→...)
- **No duplicates** — when a run is found both via lucene-index and as a downstream child, its `externalId` is updated in-place to show the relationship, rather than creating a duplicate entry
- **Cycle safe** — a `visited` set and a depth limit of 10 prevent infinite loops
- **Diamond safe** — each parent→child edge is always reported
- **Permission aware** — downstream CheckRuns are keyed under the downstream job, so `PermissionAwareCheckRunCollector` filters them by `Job.READ` on the correct job
- **Cached** — downstream results are cached alongside direct runs via the existing 30-second `CachingCheckRunCollector`
- **No rerun actions** — downstream CheckRuns have empty actions (the trigger chain cannot be reconstructed through Jenkins' rerun mechanism)

## Changes

### Production code (4 files)

| File | Change |
|---|---|
| `DirectCheckRunCollector.java` | Added `collectDownstreamCheckRuns`, `buildDownstreamMap`, `traverseDownstream`, `createDownstreamCheckRun`, and `buildDownstreamExternalId`. Modified `collectFor` to call downstream discovery after direct collection. |
| `AbstractCheckRunFactory.java` | Made `computeStatus` and `computeFinishedTimeStamp` `public` so `DirectCheckRunCollector` can reuse them. |
| `CheckResult.java` | Made `Category` enum `public` for cross-package access. |
| `Link.java` | Made `LinkIcon` enum `public` for cross-package access. |

### Tests (1 file, 16 tests)

| Category | Tests | What they cover |
|---|---|---|
| Regression (8) | `collectFor_noPluginsInstalled_returnsEmpty`, `collectFor_oneDirectRun_noDownstream_returnsOneRun`, `collectFor_noLuceneHits_returnsEmpty`, `collectFor_bothPluginsInstalled_mergesResults`, `collectFor_gerritTriggerMultipleAttempts_sequentialNumbers`, `collectFor_gerritTriggerMultipleJobs_perJobGrouping`, `collectFor_gerritMultiBranch_passesRunNumberAsAttempt`, `collectFor_searchBackendManagerNull_throwsMissingDependencyException` | Existing behavior preserved |
| Unit (4) | `patchSetId_toRef_correctFormat`, `patchSetId_equalsAndHashCode`, `queryRuns_jobNotFoundByLucene_throwsIllegalStateException`, `queryRuns_buildNotFoundByLucene_throwsIllegalStateException` | Core data types and error paths |
| Feature (4) | `collectFor_oneDownstream_notInLucene_createsCheckRun`, `collectFor_downstreamAlsoInLucene_updatesExternalId_noDuplicate`, `collectFor_deepChain_allDownstreamsDiscovered`, `collectFor_downstreamRerunAction_notAdded` | New downstream discovery behavior |

### Coverage (key files)

| Class | Instruction | Branch | Line | Method |
|---|---|---|---|---|
| `DirectCheckRunCollector` | 96.4% | 85.5% | 94.8% | 100% |
| `PatchSetId` | 100% | 100% | 100% | 100% |

## No breaking changes

- REST endpoint (`GET /gerrit-checks/runs?change=X&patchset=Y`) returns the same JSON structure — just more entries
- `CheckRun.externalId` for direct runs unchanged (`"jobName#buildNumber"`)
- `CheckRunCollector` interface, Guice bindings, and caching unchanged

### Testing done

Deployed in infrastructure and check against checks-jenkins plugin:

https://github.com/amarula/checks-jenkins

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
