### PR TITLE
Exclude merged changes from Gerrit trigger check run collection

### DIFF
--- a/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
+++ b/src/main/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollector.java
@@ -91,7 +91,7 @@ public class DirectCheckRunCollector implements CheckRunCollector {
   private Map<Job<?, ?>, List<CheckRun>> collectGerritTriggerRuns(PatchSetId ps) {
     SearchBackendManager manager = getSearchBackendManager();
     try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
-      Map<Job<?, ?>, List<Run>> hits = queryRuns(String.format("p:\"refs/changes/%s\"", ps.toRef()), manager).stream()
+      Map<Job<?, ?>, List<Run>> hits = queryRuns(String.format("p:\"refs/changes/%s\" -p:\"change-merged\"", ps.toRef()), manager).stream()
               .sorted(Comparator.comparing(Run::getNumber))
               .collect(Collectors.groupingBy(Run::getParent));
 

--- a/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
+++ b/src/test/java/io/jenkins/plugins/gerritchecksapi/DirectCheckRunCollectorTest.java
@@ -47,6 +47,7 @@ import org.jenkinsci.plugins.lucene.search.FreeTextSearchItemImplementation;
 import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -160,6 +161,29 @@ class DirectCheckRunCollectorTest {
 
     assertEquals(1, result.size());
     assertEquals("trigger-job#5", result.get(job).get(0).getExternalId());
+  }
+
+  @Test
+  void collectFor_gerritTrigger_queryExcludesMergedChanges() {
+    when(jenkins.getPlugin("gerrit-trigger")).thenReturn(mock(hudson.Plugin.class));
+    when(jenkins.getPlugin("gerrit-code-review")).thenReturn(null);
+
+    Job job = mockJob("trigger-job", "trigger-job");
+    Run run = mockRun("trigger-job", 5, job);
+
+    when(manager.getHits(anyString(), anyBoolean()))
+        .thenReturn(Collections.singletonList(mockHit("trigger-job", "trigger-job#5")));
+    when(jenkins.getItemByFullName("trigger-job", Job.class)).thenReturn(job);
+    when(job.getBuild("5")).thenReturn(run);
+    when(triggerFactory.create(any(), any(), any(), anyInt()))
+        .thenReturn(createPlainCheckRun(1, 1, "trigger-job#5"));
+
+    collector.collectFor(PatchSetId.create(1, 1));
+
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    verify(manager).getHits(queryCaptor.capture(), anyBoolean());
+    assertEquals("p:\"refs/changes/01/1/1\" -p:\"change-merged\"",
+        queryCaptor.getValue());
   }
 
   @Test


### PR DESCRIPTION
Merged changes are no longer actionable for re-check, so filter them out of the Lucene query with -p:"change-merged" before collecting check runs.

### Testing done

I have a verified pipeline and a release pipeline. The release pipeline can be trigger even by merge event that is used
as reference build for coverage and warning-ng. Now in gerrit we want to show only trigger build by verification and
not the merged one. We can exclude filtering by the query. The unit test is not perfect now but test on the field look
good

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
